### PR TITLE
Scale markers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4354,12 +4354,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4374,17 +4376,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4501,7 +4506,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4513,6 +4519,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4527,6 +4534,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4534,12 +4542,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -4558,6 +4568,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4638,7 +4649,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4650,6 +4662,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4771,6 +4784,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/rating-scales",
-  "version": "0.4.0-beta.1",
+  "version": "0.5.0",
   "description": "Reusable React Components for Rating Scales as used by the DECSYS Project",
   "main": "lib/index.js",
   "files": [

--- a/samples/ellipse.html
+++ b/samples/ellipse.html
@@ -45,7 +45,11 @@
           scaleMarkerOptions={{
             markerColor: "red",
             length: "50px",
-            thickness: "1em"
+            thickness: "1em",
+            subLength: "20px",
+            subThickness: "0.5em",
+            markers: 5,
+            subdivisions: 10
           }}
           frameHeight="300px"
           penOptions={{
@@ -59,15 +63,15 @@
     <script>
       document.addEventListener("EllipseCompleted", e => {
         document.querySelector("#results").innerHTML = `<dl>
-                                                              <dt>Min</dt><dd>${
-                                                                e.detail
-                                                                  .minRangeValue
-                                                              }</dd>
-                                                              <dt>Max</dt><dd>${
-                                                                e.detail
-                                                                  .maxRangeValue
-                                                              }</dd>
-                                                          </dl>`;
+                                                                    <dt>Min</dt><dd>${
+                                                                      e.detail
+                                                                        .minRangeValue
+                                                                    }</dd>
+                                                                    <dt>Max</dt><dd>${
+                                                                      e.detail
+                                                                        .maxRangeValue
+                                                                    }</dd>
+                                                                </dl>`;
       });
     </script>
   </body>

--- a/samples/ellipse.html
+++ b/samples/ellipse.html
@@ -46,8 +46,9 @@
             markerColor: "red",
             length: "50px",
             thickness: "1em",
+            subColor: "green",
+            subThickness: "0.2em",
             subLength: "20px",
-            subThickness: "0.5em",
             markers: 5,
             subdivisions: 10
           }}
@@ -63,15 +64,17 @@
     <script>
       document.addEventListener("EllipseCompleted", e => {
         document.querySelector("#results").innerHTML = `<dl>
-                                                                    <dt>Min</dt><dd>${
-                                                                      e.detail
-                                                                        .minRangeValue
-                                                                    }</dd>
-                                                                    <dt>Max</dt><dd>${
-                                                                      e.detail
-                                                                        .maxRangeValue
-                                                                    }</dd>
-                                                                </dl>`;
+                                                                          <dt>Min</dt><dd>${
+                                                                            e
+                                                                              .detail
+                                                                              .minRangeValue
+                                                                          }</dd>
+                                                                          <dt>Max</dt><dd>${
+                                                                            e
+                                                                              .detail
+                                                                              .maxRangeValue
+                                                                          }</dd>
+                                                                      </dl>`;
       });
     </script>
   </body>

--- a/samples/ellipse.html
+++ b/samples/ellipse.html
@@ -63,18 +63,11 @@
     </script>
     <script>
       document.addEventListener("EllipseCompleted", e => {
-        document.querySelector("#results").innerHTML = `<dl>
-                                                                          <dt>Min</dt><dd>${
-                                                                            e
-                                                                              .detail
-                                                                              .minRangeValue
-                                                                          }</dd>
-                                                                          <dt>Max</dt><dd>${
-                                                                            e
-                                                                              .detail
-                                                                              .maxRangeValue
-                                                                          }</dd>
-                                                                      </dl>`;
+        document.querySelector("#results").innerHTML = `
+                <dl>
+                  <dt>Min</dt><dd>${e.detail.minRangeValue}</dd>
+                  <dt>Max</dt><dd>${e.detail.maxRangeValue}</dd>
+                </dl>`;
       });
     </script>
   </body>

--- a/samples/ellipse.html
+++ b/samples/ellipse.html
@@ -42,6 +42,11 @@
             length: "100px",
             thickness: "1px"
           }}
+          scaleMarkerOptions={{
+            markerColor: "red",
+            length: "50px",
+            thickness: "1em"
+          }}
           frameHeight="300px"
           penOptions={{
             color: "red",
@@ -54,13 +59,15 @@
     <script>
       document.addEventListener("EllipseCompleted", e => {
         document.querySelector("#results").innerHTML = `<dl>
-                                                        <dt>Min</dt><dd>${
-                                                          e.detail.minRangeValue
-                                                        }</dd>
-                                                        <dt>Max</dt><dd>${
-                                                          e.detail.maxRangeValue
-                                                        }</dd>
-                                                    </dl>`;
+                                                              <dt>Min</dt><dd>${
+                                                                e.detail
+                                                                  .minRangeValue
+                                                              }</dd>
+                                                              <dt>Max</dt><dd>${
+                                                                e.detail
+                                                                  .maxRangeValue
+                                                              }</dd>
+                                                          </dl>`;
       });
     </script>
   </body>

--- a/samples/likert.html
+++ b/samples/likert.html
@@ -36,10 +36,11 @@
     <script>
       document.addEventListener("LikertSelected", e => {
         console.log("handled LikertSelected");
-        document.querySelector("#results").innerHTML = `<dl>
-                                <dt>Value</dt><dd>${e.detail.value}</dd>
-                                <dt>Index</dt><dd>${e.detail.index}</dd>
-                            </dl>`;
+        document.querySelector("#results").innerHTML = `
+                <dl>
+                  <dt>Value</dt><dd>${e.detail.value}</dd>
+                  <dt>Index</dt><dd>${e.detail.index}</dd>
+                </dl>`;
       });
     </script>
   </body>

--- a/src/core/StyledBarContainer.js
+++ b/src/core/StyledBarContainer.js
@@ -1,0 +1,14 @@
+import styled from "styled-components";
+
+/**
+ * Simply provides a container for children of a ScaleBar
+ * that will be evenly spaced out using flexbox
+ */
+const StyledBarContainer = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+`;
+
+/** @component */
+export default StyledBarContainer;

--- a/src/core/StyledScaleBar.js
+++ b/src/core/StyledScaleBar.js
@@ -14,8 +14,6 @@ export const ClassName = "js--scalebar";
 const StyledScaleBar = styled.div.attrs({
   className: ClassName
 })`
-  display: flex;
-  justify-content: space-between;
   margin-left: ${props => props.leftMargin};
   margin-right: ${props => props.rightMargin};
   position: relative;

--- a/src/ellipse/RangeMarker.js
+++ b/src/ellipse/RangeMarker.js
@@ -1,21 +1,14 @@
 import styled from "styled-components";
 import PropTypes from "prop-types";
+import ScaleMarker from "./ScaleMarker";
 
 /**
  * A marker for the RangeBar to indicate
  * the range of an ellipse drawn against the bar
  */
-const RangeMarker = styled.div`
-  position: absolute;
+const RangeMarker = styled(ScaleMarker)`
   &::before {
-    border-left: ${props =>
-      `${props.markerThickness} solid ${props.markerColor}`};
-    position: absolute;
-    min-height: ${props => props.markerLength};
-    top: ${props => `calc(${props.markerLength} / -2)`};
-    left: ${props => `calc(${props.markerThickness} / -2)`};
-    z-index: 2;
-    content: "";
+    z-index: 3;
   }
 `;
 

--- a/src/ellipse/Scale.js
+++ b/src/ellipse/Scale.js
@@ -9,6 +9,7 @@ import Pen from "./pen-line";
 import Frame from "../core/StyledFrame";
 import Question from "../core/StyledQuestion";
 import UnitValue from "unit-value";
+import ScaleMarkerSet from "./ScaleMarkerSet";
 
 // private static helpers
 
@@ -124,6 +125,16 @@ export default class EllipseScale extends React.Component {
 
     /** Options for the Range Markers appearance */
     rangeMarkerOptions: PropTypes.shape({
+      /** A valid CSS Color value for the marker */
+      markerColor: PropTypes.string,
+      /** A valid CSS Dimension value for the length of the marker */
+      length: PropTypes.string,
+      /** A valid CSS Dimension value for the thickness of the marker */
+      thickness: PropTypes.string
+    }),
+
+    /** Options for the Scale Markers */
+    scaleMarkerOptions: PropTypes.shape({
       /** A valid CSS Color value for the marker */
       markerColor: PropTypes.string,
       /** A valid CSS Dimension value for the length of the marker */
@@ -265,12 +276,12 @@ export default class EllipseScale extends React.Component {
     // pre-calculate these so they can apply to both markers
     const rangeMarkerProps = {
       markerColor: this.props.rangeMarkerOptions.markerColor,
-      markerThickness:
+      thickness:
         this.props.rangeMarkerOptions.thickness != null
           ? this.props.rangeMarkerOptions.thickness
           : this.props.barOptions.thickness,
 
-      markerLength:
+      length:
         this.props.rangeMarkerOptions.length != null
           ? this.props.rangeMarkerOptions.length
           : UnitValue.multiply(this.props.barOptions.thickness, 1.5).toString()
@@ -282,6 +293,7 @@ export default class EllipseScale extends React.Component {
           {this.props.question}
         </Question>
         <RangeBar ref={e => (this.rangeBar = e)} {...this.props.barOptions}>
+          <ScaleMarkerSet {...this.props.scaleMarkerOptions} />
           {labels}
           <RangeMarker {...rangeMarkerProps} ref={e => (this.minMarker = e)} />
           <RangeMarker {...rangeMarkerProps} ref={e => (this.maxMarker = e)} />

--- a/src/ellipse/Scale.js
+++ b/src/ellipse/Scale.js
@@ -8,6 +8,7 @@ import EllipseCanvas, * as Canvas from "./Canvas";
 import Pen from "./pen-line";
 import Frame from "../core/StyledFrame";
 import Question from "../core/StyledQuestion";
+import FlexContainer from "../core/StyledBarContainer";
 import UnitValue from "unit-value";
 import ScaleMarkerSet from "./ScaleMarkerSet";
 
@@ -293,8 +294,10 @@ export default class EllipseScale extends React.Component {
           {this.props.question}
         </Question>
         <RangeBar ref={e => (this.rangeBar = e)} {...this.props.barOptions}>
-          <ScaleMarkerSet {...this.props.scaleMarkerOptions} />
-          {labels}
+          <FlexContainer>
+            <ScaleMarkerSet {...this.props.scaleMarkerOptions} />
+          </FlexContainer>
+          <FlexContainer>{labels}</FlexContainer>
           <RangeMarker {...rangeMarkerProps} ref={e => (this.minMarker = e)} />
           <RangeMarker {...rangeMarkerProps} ref={e => (this.maxMarker = e)} />
         </RangeBar>

--- a/src/ellipse/Scale.js
+++ b/src/ellipse/Scale.js
@@ -288,6 +288,16 @@ export default class EllipseScale extends React.Component {
           : UnitValue.multiply(this.props.barOptions.thickness, 1.5).toString()
     };
 
+    // adjust scale marker defaults if necessary
+    this.props.scaleMarkerOptions.thickness =
+      this.props.scaleMarkerOptions.thickness != null
+        ? this.props.scaleMarkerOptions.thickness
+        : this.props.barOptions.thickness;
+    this.props.scaleMarkerOptions.length =
+      this.props.scaleMarkerOptions.length != null
+        ? this.props.scaleMarkerOptions.length
+        : UnitValue.multiply(this.props.barOptions.thickness, 8).toString();
+
     return [
       <Frame key="EllipseFrame" frameHeight={this.props.frameHeight}>
         <Question {...this.props.questionOptions}>

--- a/src/ellipse/ScaleMarker.js
+++ b/src/ellipse/ScaleMarker.js
@@ -7,12 +7,11 @@ import PropTypes from "prop-types";
 const ScaleMarker = styled.div`
   position: absolute;
   &::before {
-    border-left: ${props =>
-      `${props.markerThickness} solid ${props.markerColor}`};
+    border-left: ${props => `${props.thickness} solid ${props.markerColor}`};
     position: absolute;
-    min-height: ${props => props.markerLength};
-    top: ${props => `calc(${props.markerLength} / -2)`};
-    left: ${props => `calc(${props.markerThickness} / -2)`};
+    min-height: ${props => props.length};
+    top: ${props => `calc(${props.length} / -2)`};
+    left: ${props => `calc(${props.thickness} / -2)`};
     z-index: 2;
     content: "";
   }

--- a/src/ellipse/ScaleMarker.js
+++ b/src/ellipse/ScaleMarker.js
@@ -1,0 +1,37 @@
+import styled from "styled-components";
+import PropTypes from "prop-types";
+
+/**
+ * A marker for the RangeBar to indicate a point along the scale
+ */
+const ScaleMarker = styled.div`
+  position: absolute;
+  &::before {
+    border-left: ${props =>
+      `${props.markerThickness} solid ${props.markerColor}`};
+    position: absolute;
+    min-height: ${props => props.markerLength};
+    top: ${props => `calc(${props.markerLength} / -2)`};
+    left: ${props => `calc(${props.markerThickness} / -2)`};
+    z-index: 2;
+    content: "";
+  }
+`;
+
+ScaleMarker.propTypes = {
+  /** A valid CSS Color value for the marker */
+  markerColor: PropTypes.string,
+
+  /** A valid CSS Dimension value for the length of the marker */
+  length: PropTypes.string,
+
+  /** A valid CSS Dimension value for the thickness of the marker */
+  thickness: PropTypes.string
+};
+
+ScaleMarker.defaultProps = {
+  markerColor: "black"
+};
+
+/** @component */
+export default ScaleMarker;

--- a/src/ellipse/ScaleMarkerSet.js
+++ b/src/ellipse/ScaleMarkerSet.js
@@ -1,0 +1,31 @@
+import React from "React";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+import ScaleMarker from "./ScaleMarker";
+
+const ScaleMarkerContainer = styled.div`
+  position: relative;
+`;
+
+/** A set of equally spaced ScaleMarkers, essentially forming a scale along the RangeBar */
+export default class ScaleMarkerSet extends React.Component {
+  static propTypes = {
+    /** A valid CSS Color value for the marker */
+    markerColor: PropTypes.string,
+    /** A valid CSS Dimension value for the length of the marker */
+    length: PropTypes.string,
+    /** A valid CSS Dimension value for the thickness of the marker */
+    thickness: PropTypes.string
+  };
+
+  render() {
+    return [
+      <ScaleMarkerContainer key={"marker1"}>
+        <ScaleMarker {...this.props} />
+      </ScaleMarkerContainer>,
+      <ScaleMarkerContainer key={"marker2"}>
+        <ScaleMarker {...this.props} />
+      </ScaleMarkerContainer>
+    ];
+  }
+}

--- a/src/ellipse/ScaleMarkerSet.js
+++ b/src/ellipse/ScaleMarkerSet.js
@@ -36,9 +36,16 @@ export default class ScaleMarkerSet extends React.Component {
     const markers = [];
     const nMarkers = this.props.subdivisions * (this.props.markers - 1) + 1;
     const subProps = {
-      markerColor: this.props.subColor,
-      length: this.props.subLength,
-      thickness: this.props.subThickness
+      markerColor:
+        this.props.subColor != null
+          ? this.props.subColor
+          : this.props.markerColor,
+      length:
+        this.props.subLength != null ? this.props.subLength : this.props.length,
+      thickness:
+        this.props.subThickness != null
+          ? this.props.subThickness
+          : this.props.thickness
     };
     for (let i = 0; i < nMarkers; i++) {
       const major = i === 0 || i % this.props.subdivisions === 0;

--- a/src/ellipse/ScaleMarkerSet.js
+++ b/src/ellipse/ScaleMarkerSet.js
@@ -10,22 +10,45 @@ const ScaleMarkerContainer = styled.div`
 /** A set of equally spaced ScaleMarkers, essentially forming a scale along the RangeBar */
 export default class ScaleMarkerSet extends React.Component {
   static propTypes = {
-    /** A valid CSS Color value for the marker */
+    /** A valid CSS Color value for major markers */
     markerColor: PropTypes.string,
-    /** A valid CSS Dimension value for the length of the marker */
+    /** A valid CSS Dimension value for the length of major markers */
     length: PropTypes.string,
-    /** A valid CSS Dimension value for the thickness of the marker */
-    thickness: PropTypes.string
+    /** A valid CSS Dimension value for the thickness of major markers */
+    thickness: PropTypes.string,
+    /** A valid CSS Color value for subdivision markers */
+    subColor: PropTypes.string,
+    /** A valid CSS Dimension value for the length of subdivision markers */
+    subLength: PropTypes.string,
+    /** A valid CSS Dimension value for the thickness of subdividision markers */
+    subThickness: PropTypes.string,
+    /** The number of major markers to display along the scale bar */
+    markers: PropTypes.number,
+    /** The number of marker subdivisions */
+    subdivisions: PropTypes.number
+  };
+
+  static defaultProps = {
+    subdivisions: 1
   };
 
   render() {
-    return [
-      <ScaleMarkerContainer key={"marker1"}>
-        <ScaleMarker {...this.props} />
-      </ScaleMarkerContainer>,
-      <ScaleMarkerContainer key={"marker2"}>
-        <ScaleMarker {...this.props} />
-      </ScaleMarkerContainer>
-    ];
+    const markers = [];
+    const nMarkers = this.props.subdivisions * (this.props.markers - 1) + 1;
+    const subProps = {
+      markerColor: this.props.subColor,
+      length: this.props.subLength,
+      thickness: this.props.subThickness
+    };
+    for (let i = 0; i < nMarkers; i++) {
+      const major = i === 0 || i % this.props.subdivisions === 0;
+      markers.push(
+        <ScaleMarkerContainer key={`scaleMarker${i}`}>
+          <ScaleMarker {...(major ? this.props : subProps)} />
+        </ScaleMarkerContainer>
+      );
+    }
+
+    return markers;
   }
 }

--- a/src/ellipse/ScaleMarkerSet.js
+++ b/src/ellipse/ScaleMarkerSet.js
@@ -1,4 +1,4 @@
-import React from "React";
+import React from "react";
 import PropTypes from "prop-types";
 import styled from "styled-components";
 import ScaleMarker from "./ScaleMarker";

--- a/src/likert/Scale.js
+++ b/src/likert/Scale.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import Frame from "../core/StyledFrame";
 import ScaleBar from "../core/StyledScaleBar";
 import Question from "../core/StyledQuestion";
+import FlexContainer from "../core/StyledBarContainer";
 import Radio from "./Radio";
 
 /** A Likert Scale */
@@ -99,7 +100,9 @@ export default class LikertScale extends React.Component {
         <Question {...this.props.questionOptions}>
           {this.props.question}
         </Question>
-        <ScaleBar {...this.props.barOptions}>{radios}</ScaleBar>
+        <ScaleBar {...this.props.barOptions}>
+          <FlexContainer>{radios}</FlexContainer>
+        </ScaleBar>
       </Frame>
     );
   }


### PR DESCRIPTION
- The `RangeBar` in the `EllipseScale` can now have a set of markers evenly spaced along it
- It supports the same marker options as the range markers: color, thickness, length
- It supports differently styled subdivision markers as well as major division markers.