### PR TITLE
Empty shape props

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/rating-scales",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Reusable React Components for Rating Scales as used by the DECSYS Project",
   "main": "lib/index.js",
   "files": [

--- a/src/ellipse/Scale.js
+++ b/src/ellipse/Scale.js
@@ -145,6 +145,18 @@ export default class EllipseScale extends React.Component {
     })
   };
 
+  static defaultProps = {
+    // default all shapes to empty objects
+    // so we don't have to null check before accessing children
+    penOptions: {},
+    questionOptions: {},
+    barOptions: {},
+    labelOptions: {},
+    labels: {},
+    rangeMarkerOptions: {},
+    scaleMarkerOptions: {}
+  };
+
   componentDidMount() {
     // store these to avoid selecting them everytime
     this.mainElement = document.querySelector("body");

--- a/src/likert/Scale.js
+++ b/src/likert/Scale.js
@@ -70,6 +70,8 @@ export default class LikertScale extends React.Component {
   };
 
   static defaultProps = {
+    barOptions: {},
+    questionOptions: {},
     radioOptions: {
       labelAlignment: "below"
     },


### PR DESCRIPTION
Both Scale components required props that were shapes to be passed, even if their child properties weren't specified (causing defaults to be used).

Now the top level scale components (with the shape props) default their shape props to an empty object, to simplify the application of defaults in sub-components.