### PR TITLE
Height elements proptype

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/rating-scales",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Reusable React Components for Rating Scales as used by the DECSYS Project",
   "main": "lib/index.js",
   "files": [

--- a/src/ellipse/Scale.js
+++ b/src/ellipse/Scale.js
@@ -33,8 +33,14 @@ export default class EllipseScale extends React.Component {
   }
 
   static propTypes = {
-    /** An array of elements to consider for calculating canvas height */
-    heightElements: PropTypes.arrayOf(PropTypes.element),
+    /**
+     * An array of css selectors for elements
+     * to be used for calculating canvas height
+     */
+    heightElements: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.arrayOf(PropTypes.string)
+    ]),
 
     /** A valid CSS Dimension value for the height of the component's frame */
     frameHeight: PropTypes.string,


### PR DESCRIPTION
the prop type for this was incorrect in two ways:

- it expected react elements, when it should've expected css selector strings
- it always expected an array; in practice a single string is also valid