### PR TITLE
1.0.0-beta.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,8 @@
 # Build output
 docs
-dist
-lib
+cjs
+esm
+umd
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -17,30 +17,30 @@ The DECSYS Project uses them for survey question components for its Survey Platf
 
 `npm install @decsys/rating-scales`
 
-## Node
+## ES Modules / CommonJS (Node)
 
 The complete Scale components are accessible from the main package export.
 
-Additionally, all the components are default exports from individual modules, so can be referenced directly.
+Additionally, all the Scale components are default exports from individual modules, so can be referenced directly. This can enable tree shaking and smaller final bundles, so is recommended when in an environment that supports ES Modules.
+
+### Importing a Scale component directly from its module
+
+e.g. just the Discrete Scale
+
+- esm: `import DiscreteScale from "@decsys/rating-scales/esm/discrete";`
+- commonjs (node): `const Frame = require("@decsys/rating-scales/cjs/discrete");`
 
 ### Importing a Scale component from the main package export
 
 e.g. all Scales
 
-- `import * as DECSYS from "@decsys/rating-scales";`
-- `const DECSYS = require("@decsys/rating-scales");`
+- esm: `import * as DECSYS from "@decsys/rating-scales";`
+- commonjs (node): `const DECSYS = require("@decsys/rating-scales");`
 
 e.g. for just the Discrete Scale
 
-- `import { DiscreteScale } from "@decsys/rating-scales";`
-- `const DiscreteScale = require("@decsys/rating-scales").DiscreteScale;`
-
-### Importing a sub-component directly from its module
-
-e.g. the basic `Frame` component
-
-- `import Frame from "@decsys/rating-scales/core/Frame";`
-- `const Frame = require("@decsys/rating-scales/core/Frame");`
+- esm: `import { DiscreteScale } from "@decsys/rating-scales";`
+- commonjs (node): `const DiscreteScale = require("@decsys/rating-scales").DiscreteScale;`
 
 ## Browser
 
@@ -56,14 +56,14 @@ The following complete ratings scale components are available:
 
 - Discrete Scale
 
-  - `import { DiscreteScale } from "@decsys/rating-scales";`
-  - `const DiscreteScale = require("@decsys/rating-scales").DiscreteScale;`
-  - `DECSYS.DiscreteScale` when using the browser build.
+  - esm: `import DiscreteScale from "@decsys/rating-scales/esm/discrete";`
+  - commonjs (node): `const DiscreteScale = require("@decsys/rating-scales/cjs/discrete");`
+  - browser (umd): `DECSYS.DiscreteScale`
 
 - Ellipse Scale
-  - `import { EllipseScale } from "@decsys/rating-scales";`
-  - `const EllipseScale = require("@decsys/rating-scales").EllipseScale;`
-  - `DECSYS.EllipseScale` when using the browser build.
+  - esm: `import EllipseScale from "@decsys/rating-scales/esm/ellipse";`
+  - commonjs (node): `const EllipseScale = require("@decsys/rating-scales/cjs/ellipse");`
+  - browser (umd): `DECSYS.EllipseScale`
 
 # Documentation
 
@@ -77,7 +77,7 @@ There are a number of sub-tasks composed into higher-level tasks you're more lik
 
 - `npm run lint` will run eslint against the source.
 - `npm run rollup` will build transpiled, minified bundles (with external source maps) for Browser, CommonJS and ES Modules.
-- `npm run build` will lint and, if it passes, clear the `dist/` directory and build the bundles as above. This is used in CI.
+- `npm run build` will lint and, if it passes, build the bundles as above. This is used in CI.
 - `npm run watch [build]` will run `build` script described above and then watch for changes in the `src/` directory.
 
 # Licensing

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ e.g. all Scales
 - `import * as DECSYS from "@decsys/rating-scales";`
 - `const DECSYS = require("@decsys/rating-scales");`
 
-e.g. for just the Likert Scale
+e.g. for just the Discrete Scale
 
-- `import { LikertScale } from "@decsys/rating-scales";`
-- `const LikertScale = require("@decsys/rating-scales").LikertScale;`
+- `import { DiscreteScale } from "@decsys/rating-scales";`
+- `const DiscreteScale = require("@decsys/rating-scales").DiscreteScale;`
 
 ### Importing a sub-component directly from its module
 
@@ -54,11 +54,11 @@ The sub-components are not directly available in the browser.
 
 The following complete ratings scale components are available:
 
-- Likert Scale
+- Discrete Scale
 
-  - `import { LikertScale } from "@decsys/rating-scales";`
-  - `const LikertScale = require("@decsys/rating-scales").LikertScale;`
-  - `DECSYS.LikertScale` when using the browser build.
+  - `import { DiscreteScale } from "@decsys/rating-scales";`
+  - `const DiscreteScale = require("@decsys/rating-scales").DiscreteScale;`
+  - `DECSYS.DiscreteScale` when using the browser build.
 
 - Ellipse Scale
   - `import { EllipseScale } from "@decsys/rating-scales";`

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,8 @@ stages:
         steps:
           - script: npm ci
           - script: npm run build
-          - upload: dist
+          - bash: cp -r cjs esm umd $(Build.ArtifactStagingDirectory)
+          - upload: $(Build.ArtifactStagingDirectory)
       - job: Docs
         pool:
           vmImage: ubuntu-latest
@@ -60,13 +61,9 @@ stages:
             deploy:
               steps:
                 - checkout: self
-                - download: current
-                  artifact: drop
-                - bash: >
-                    mkdir -p $(System.DefaultWorkingDirectory)/dist &&
-
-                    cp $(Pipeline.Workspace)/drop/*
-                    $(System.DefaultWorkingDirectory)/dist
+                - bash: >-
+                    cp -r $(Pipeline.Workspace)/drop/*
+                    $(System.DefaultWorkingDirectory)
                 - task: Npm@1
                   inputs:
                     command: publish

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@decsys/rating-scales",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1938,7 +1938,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -2324,7 +2324,7 @@
     },
     "browserify-aes": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
@@ -2361,7 +2361,7 @@
     },
     "browserify-rsa": {
       "version": "4.0.1",
-      "resolved": "http://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
       "dev": true,
       "requires": {
@@ -2446,7 +2446,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -3179,7 +3179,7 @@
     },
     "create-hash": {
       "version": "1.2.0",
-      "resolved": "http://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
@@ -3192,7 +3192,7 @@
     },
     "create-hmac": {
       "version": "1.1.7",
-      "resolved": "http://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
@@ -3551,7 +3551,7 @@
     },
     "diffie-hellman": {
       "version": "5.0.3",
-      "resolved": "http://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+      "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
       "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
       "dev": true,
       "requires": {
@@ -3620,7 +3620,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -4338,7 +4338,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "dev": true,
       "requires": {
@@ -5112,7 +5112,7 @@
     },
     "get-stream": {
       "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
       "dev": true
     },
@@ -5459,7 +5459,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -6569,7 +6569,7 @@
     },
     "media-typer": {
       "version": "0.3.0",
-      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
       "dev": true
     },
@@ -6782,7 +6782,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7221,7 +7221,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -8383,7 +8383,7 @@
     },
     "readable-stream": {
       "version": "2.3.6",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "dev": true,
       "requires": {
@@ -8887,7 +8887,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -9088,7 +9088,7 @@
     },
     "sha.js": {
       "version": "2.4.11",
-      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
@@ -9602,7 +9602,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -9866,7 +9866,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -2,11 +2,13 @@
   "name": "@decsys/rating-scales",
   "version": "1.0.0-beta.3",
   "description": "Reusable React Components for Rating Scales as used by the DECSYS Project",
-  "main": "dist/decsys.rating-scales.bundle.cjs.js",
-  "browser": "dist/decsys.rating-scales.umd.js",
-  "module": "dist/decsys.rating-scales.bundle.esm.js",
+  "main": "cjs/decsys.rating-scales.js",
+  "browser": "umd/decsys.rating-scales.js",
+  "module": "esm/decsys.rating-scales.js",
   "files": [
-    "dist"
+    "umd",
+    "cjs",
+    "esm"
   ],
   "publishConfig": {
     "access": "public"

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@decsys/rating-scales",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Reusable React Components for Rating Scales as used by the DECSYS Project",
-  "main": "dist/decsys.rating-scales.cjs.js",
+  "main": "dist/decsys.rating-scales.bundle.cjs.js",
   "browser": "dist/decsys.rating-scales.umd.js",
-  "module": "dist/decsys.rating-scales.esm.js",
+  "module": "dist/decsys.rating-scales.bundle.esm.js",
   "files": [
     "dist"
   ],

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,8 +19,8 @@ const plugins = [
 const bundleEntryPoint = "src/index.js";
 const input = {
   [pkg.name.replace("@", "").replace("/", ".")]: bundleEntryPoint,
-  ellipse: "src/Ellipse/Scale.js",
-  discrete: "src/Discrete/Scale.js"
+  ellipse: "src/ellipse/Scale.js",
+  discrete: "src/discrete/Scale.js"
 };
 
 const entryFileNames = `[name].js`;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,10 +16,22 @@ const plugins = [
   terser()
 ];
 
+const filePrefix = pkg.name.replace("@", "").replace("/", ".");
+
+const input = {
+  bundle: "src/index.js",
+  ellipse: "src/Ellipse/Scale.js",
+  discrete: "src/Discrete/Scale.js"
+};
+
+const dir = "dist";
+
+const entryFileNames = `${filePrefix}.[name].[format].js`;
+
 export default [
   // browser
   {
-    input: "src/index.js",
+    input: input.bundle,
     output: {
       name: "DECSYS",
       file: pkg.browser,
@@ -35,10 +47,11 @@ export default [
   },
   // commonjs, esm
   {
-    input: "src/index.js",
+    input,
     output: [
       {
-        file: pkg.main,
+        dir,
+        entryFileNames,
         format: "cjs",
         sourcemap: true,
         globals: {
@@ -47,7 +60,8 @@ export default [
         }
       },
       {
-        file: pkg.module,
+        dir,
+        entryFileNames,
         format: "esm",
         sourcemap: true,
         globals: {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,22 +16,19 @@ const plugins = [
   terser()
 ];
 
-const filePrefix = pkg.name.replace("@", "").replace("/", ".");
-
+const bundleEntryPoint = "src/index.js";
 const input = {
-  bundle: "src/index.js",
+  [pkg.name.replace("@", "").replace("/", ".")]: bundleEntryPoint,
   ellipse: "src/Ellipse/Scale.js",
   discrete: "src/Discrete/Scale.js"
 };
 
-const dir = "dist";
-
-const entryFileNames = `${filePrefix}.[name].[format].js`;
+const entryFileNames = `[name].js`;
 
 export default [
   // browser
   {
-    input: input.bundle,
+    input: bundleEntryPoint,
     output: {
       name: "DECSYS",
       file: pkg.browser,
@@ -50,7 +47,7 @@ export default [
     input,
     output: [
       {
-        dir,
+        dir: "cjs",
         entryFileNames,
         format: "cjs",
         sourcemap: true,
@@ -60,7 +57,7 @@ export default [
         }
       },
       {
-        dir,
+        dir: "esm",
         entryFileNames,
         format: "esm",
         sourcemap: true,

--- a/samples/ellipse.html
+++ b/samples/ellipse.html
@@ -13,7 +13,7 @@
     <script src="../node_modules/styled-components/dist/styled-components.js"></script>
     <script src="../node_modules/@babel/standalone/babel.min.js"></script>
 
-    <script src="../dist/decsys.rating-scales.umd.js"></script>
+    <script src="../umd/decsys.rating-scales.js"></script>
 
     <script type="text/babel">
       ReactDOM.render(

--- a/samples/likert.html
+++ b/samples/likert.html
@@ -13,7 +13,7 @@
     <script src="../node_modules/styled-components/dist/styled-components.js"></script>
     <script src="../node_modules/@babel/standalone/babel.min.js"></script>
 
-    <script src="../dist/decsys.rating-scales.umd.js"></script>
+    <script src="../umd/decsys.rating-scales.js"></script>
 
     <script type="text/babel">
       ReactDOM.render(

--- a/samples/likert.html
+++ b/samples/likert.html
@@ -1,11 +1,11 @@
 <html>
   <head>
-    <title>React Likert</title>
+    <title>React Discrete</title>
     <meta charset="utf-8" />
   </head>
 
   <body>
-    <div id="likert"></div>
+    <div id="discrete"></div>
     <div id="results"></div>
 
     <script src="../node_modules/react/umd/react.development.js"></script>
@@ -17,7 +17,7 @@
 
     <script type="text/babel">
       ReactDOM.render(
-        <DECSYS.LikertScale
+        <DECSYS.DiscreteScale
           radios={[["1", "Low"], ["2"], ["3"], ["4"], ["5", "High"]]}
           radioOptions={{
             labelAlignment: "above",
@@ -31,12 +31,12 @@
             textColor: "orange"
           }}
         />,
-        document.querySelector("#likert")
+        document.querySelector("#discrete")
       );
     </script>
     <script>
-      document.addEventListener("LikertSelected", e => {
-        console.log("handled LikertSelected");
+      document.addEventListener("DiscreteSelected", e => {
+        console.log("handled DiscreteSelected");
         document.querySelector("#results").innerHTML = `
           <dl>
             <dt>Value</dt><dd>${e.detail.value}</dd>

--- a/src/core/overview.md
+++ b/src/core/overview.md
@@ -1,1 +1,1 @@
-The core components are essentially reusable styled primitives that can be combined with specialist components to form a complete Ratings Scale component such as a Likert Scale.
+The core components are essentially reusable styled primitives that can be combined with specialist components to form a complete Ratings Scale component such as a Discrete Scale.

--- a/src/discrete/Radio.js
+++ b/src/discrete/Radio.js
@@ -45,7 +45,7 @@ const SecondaryRadioLabel = styled(RadioLabel)`
  */
 const RadioInput = styled.input.attrs({
   type: "radio",
-  name: "likert"
+  name: "discrete"
 })`
   transform: scale(2);
 `;
@@ -60,7 +60,7 @@ const RadioContainer = styled.div`
 `;
 
 /**
- * A Labelled Radio Button component for use on the Likert Scale
+ * A Labelled Radio Button component for use on the Discrete Scale
  */
 export default class Radio extends React.Component {
   static propTypes = {
@@ -101,7 +101,7 @@ export default class Radio extends React.Component {
 
   radioClickHandler = () => {
     document.dispatchEvent(
-      new CustomEvent("LikertSelected", {
+      new CustomEvent("DiscreteSelected", {
         detail: {
           index: this.props.index,
           value: this.props.value

--- a/src/discrete/Scale.js
+++ b/src/discrete/Scale.js
@@ -6,8 +6,8 @@ import Question from "../core/StyledQuestion";
 import FlexContainer from "../core/StyledBarContainer";
 import Radio from "./Radio";
 
-/** A Likert Scale */
-export default class LikertScale extends React.Component {
+/** A Discrete Scale */
+export default class DiscreteScale extends React.Component {
   static propTypes = {
     /** Options for the scale's radio inputs */
     radioOptions: PropTypes.shape({

--- a/src/discrete/overview.md
+++ b/src/discrete/overview.md
@@ -1,0 +1,1 @@
+Components that make up the main Discrete Scale

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import LikertScale from "./likert/Scale";
+import DiscreteScale from "./discrete/Scale";
 import EllipseScale from "./ellipse/Scale";
 
-export { LikertScale, EllipseScale };
+export { DiscreteScale, EllipseScale };

--- a/src/likert/overview.md
+++ b/src/likert/overview.md
@@ -1,1 +1,0 @@
-Components that make up the main Likert Scale

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -20,9 +20,9 @@ module.exports = {
       components: ["src/core/*.js"]
     },
     {
-      name: "Likert Scale",
-      content: "src/likert/overview.md",
-      components: ["src/likert/*.js"]
+      name: "Discrete Scale",
+      content: "src/discrete/overview.md",
+      components: ["src/discrete/*.js"]
     },
     {
       name: "Ellipse Scale",


### PR DESCRIPTION
- Likert Scale has been renamed Discrete Scale for clarity and accuracy
- Code splitting is used for the CommonJS and ES Module bundles.
    - this allows more granular importing of specific scales, which will later result in tree shaking when supported
    - as a practical example at this time, it means using the Discrete Scale allows you not to bundle `pixi.js` as that is currently only used by the Ellipse Scale.